### PR TITLE
1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.2
 
-- The script will now throw a better error when you don't have permission to kill the process
+- The script will now throw a better error when you don't have permission to kill the process.
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.2
 
-- Added permission denied specific error while attempting to kill a port.
+- The script will now throw a better error when you don't have permission to kill the process
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Added permission denied specific error while attempting to kill a port.
+
 ## 1.0.1
 
 - Made the script a bit more aggressive in its attempt to kill the process.

--- a/killport.js
+++ b/killport.js
@@ -91,7 +91,10 @@ function killProcessOnPort (port) {
       process.kill(pid, 'SIGKILL')
       if (!silent) console.log(`Killed process ${pid} running on port ${port}`)
     } catch (err) {
-      if (!silent) console.error(`Error killing process ${pid}: `, err)
+      if (!silent) {
+        const error = err.code === 'EPERM' ? 'Permission denied' : err
+        console.error(`Error killing process ${pid}:`, error)
+      }
     }
   } else {
     if (!silent) console.log(`No process found running on port ${port}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "standard": "17.1.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://www.paypal.com/donate/?hosted_button_id=2L2X8GRXZCGJ6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crossplatform-killport",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crossplatform-killport",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "CC-BY-4.0",
       "bin": {
         "killport": "killport.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/crossplatform-killport/graphs/contributors"
     }
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "files": [
     "killport.js",
     "*.md"


### PR DESCRIPTION
- The script will now throw a better error when you don't have permission to kill the process.

closes https://github.com/rooseveltframework/crossplatform-killport/issues/5